### PR TITLE
修复快手报错

### DIFF
--- a/src/Logic/H5KuaiShouLogic.php
+++ b/src/Logic/H5KuaiShouLogic.php
@@ -30,11 +30,11 @@ class H5KuaiShouLogic extends Base
                 throw new ErrorVideoException("did获取不到");
             }
             $did = $matches[1];
-            preg_match('/client_key=(.*?);/', $cookie, $matches);
-            if (CommonUtil::checkEmptyMatch($matches)) {
-                throw new ErrorVideoException("client_key获取不到");
-            }
-            $clientKey = $matches[1];
+//            preg_match('/client_key=(.*?);/', $cookie, $matches);
+//            if (CommonUtil::checkEmptyMatch($matches)) {
+//                throw new ErrorVideoException("client_key获取不到");
+//            }
+            $clientKey = ''; //$matches[1];
             preg_match('/clientid=([0-9]);/', $cookie, $matches);
             $clientId = isset($matches[1]) ? $matches[1] : 3;
             $cookie   = 'did=' . $did . '; client_key=' . $clientKey . '; clientid=' . $clientId . '; didv=' . time() . '000;';


### PR DESCRIPTION
快手获取 client_id 异常，注释该段代买，暂时不影响使用